### PR TITLE
Agraus/ats integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,21 +136,29 @@ endif
 ifeq ($(netcdfsys), not-set)
   NETCDF_FFLAGS =""
   NETCDF_FLIBS =""
-else ifeq($(ATS), 1)
-	NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(TPL_INSTALL_PREFIX))/include/
-	NETCDF_FLIBS = $(shell ./nc_config --flibs --$(TPL_INSTALL_PREFIX))
-else
-  NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(CC))/include/
-  NETCDF_FLIBS = $(shell ./nc_config --flibs --$(CC))
+#else ifeq ($(ATS), 1)
+#  $(info this code is being run)
+#  NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(TPL_INSTALL_PREFIX))/include
+#  NETCDF_FLIBS = $(shell ./nc_config --flibs --$(TPL_INSTALL_PREFIX))
+#else
+#  $(info this is also running)`
+#  NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(CC))/include
+#  NETCDF_FLIBS = $(shell ./nc_config --flibs --$(CC))
+endif
+
+ifeq ($(ATS), 1)
+  $(info running second if)
+  NETCDF_FFLAGS += $(TPL_INSTALL_PREFIX)/include
+  NETCDF_FLIBS += -L$(TPL_INSTALL_PREFIX)/lib -lnetcdff -lnetcdf -lnetcdf
 endif
 
 CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(NETCDF_FFLAGS)"
 CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(NETCDF_FLIBS)"
 
-#ifeq ($(ATS), 1)
-#	CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(TPL_INSTALL_PREFIX)/include"
-#	CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(TPL_INSTALL_PREFIX)/lib"
-#endif
+$(info netcdfsys: $(netcdfsys))
+$(info netcdf flags: $(NETCDF_FFLAGS))
+$(info netcdf libs: $(NETCDF_FLIBS))
+$(info tpl install: $(TPL_INSTALL_PREFIX))
 
 define run-config
 @mkdir -p $(BUILDDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 # Makefile -- Use this to build on *NIX systems.
 
+ifeq ($(ATS), 0)
+	CC         = not-set
+	CXX        = not-set
+	FC         = not-set
+	F90        = not-set
+	netcdfsys  = not-set
+	ATS        = not-set
+endif
+
 # Options set on command line.
 debug      = not-set
 mpi        = not-set
@@ -8,15 +17,9 @@ precision  = not-set
 verbose    = not-set
 prefix     = not-set
 sanitize   = not-set
-CC         = not-set
-CXX        = not-set
-FC         = not-set
 travis     = not-set
-F90        = not-set
-netcdfsys  = not-set
-ATS        = not-set
-# This proxies everything to the builddir cmake.
 
+# This proxies everything to the builddir cmake.
 
 cputype = $(shell uname -m | sed "s/\\ /_/g")
 systype = $(shell uname -s)
@@ -45,7 +48,7 @@ endif
 
 # MPI
 ifeq ($(ATS), not-set)
-	ifeq ($(mpi), 1)
+  ifeq ($(mpi), 1)
 	  BUILDDIR := ${BUILDDIR}-mpi
 	  CC = mpicc
 	  CXX = mpicxx
@@ -70,6 +73,7 @@ ifeq ($(ATS), not-set)
 	  compiler=gnu
 	endif
 endif
+
 # Shared libs?
 ifeq ($(shared), 1)
   BUILDDIR := ${BUILDDIR}-shared
@@ -132,6 +136,9 @@ endif
 ifeq ($(netcdfsys), not-set)
   NETCDF_FFLAGS =""
   NETCDF_FLIBS =""
+else ifeq($(ATS), 1)
+	NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(TPL_INSTALL_PREFIX))/include/
+	NETCDF_FLIBS = $(shell ./nc_config --flibs --$(TPL_INSTALL_PREFIX))
 else
   NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(CC))/include/
   NETCDF_FLIBS = $(shell ./nc_config --flibs --$(CC))
@@ -140,10 +147,10 @@ endif
 CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(NETCDF_FFLAGS)"
 CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(NETCDF_FLIBS)"
 
-ifeq ($(ATS), 1)
-	CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(TPL_INSTALL_PREFIX)/include"
-	CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(TPL_INSTALL_PREFIX)/lib"
-endif
+#ifeq ($(ATS), 1)
+#	CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(TPL_INSTALL_PREFIX)/include"
+#	CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(TPL_INSTALL_PREFIX)/lib"
+#endif
 
 define run-config
 @mkdir -p $(BUILDDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 # Makefile -- Use this to build on *NIX systems.
 
-ifeq ($(ATS), 0)
+ifndef ATS
 	CC         = not-set
 	CXX        = not-set
 	FC         = not-set
 	F90        = not-set
 	netcdfsys  = not-set
-	ATS        = not-set
 endif
 
 # Options set on command line.
@@ -47,8 +46,8 @@ ifeq ($(verbose), 1)
 endif
 
 # MPI
-ifeq ($(ATS), not-set)
-  ifeq ($(mpi), 1)
+ifndef ATS
+	ifeq ($(mpi), 1)
 	  BUILDDIR := ${BUILDDIR}-mpi
 	  CC = mpicc
 	  CXX = mpicxx
@@ -136,29 +135,15 @@ endif
 ifeq ($(netcdfsys), not-set)
   NETCDF_FFLAGS =""
   NETCDF_FLIBS =""
-#else ifeq ($(ATS), 1)
-#  $(info this code is being run)
-#  NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(TPL_INSTALL_PREFIX))/include
-#  NETCDF_FLIBS = $(shell ./nc_config --flibs --$(TPL_INSTALL_PREFIX))
-#else
-#  $(info this is also running)`
-#  NETCDF_FFLAGS = $(shell ./nc_config --prefix --$(CC))/include
-#  NETCDF_FLIBS = $(shell ./nc_config --flibs --$(CC))
 endif
 
 ifeq ($(ATS), 1)
-  $(info running second if)
   NETCDF_FFLAGS += $(TPL_INSTALL_PREFIX)/include
   NETCDF_FLIBS += -L$(TPL_INSTALL_PREFIX)/lib -lnetcdff -lnetcdf -lnetcdf
 endif
 
 CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(NETCDF_FFLAGS)"
 CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(NETCDF_FLIBS)"
-
-$(info netcdfsys: $(netcdfsys))
-$(info netcdf flags: $(NETCDF_FFLAGS))
-$(info netcdf libs: $(NETCDF_FLIBS))
-$(info tpl install: $(TPL_INSTALL_PREFIX))
 
 define run-config
 @mkdir -p $(BUILDDIR)

--- a/Makefile
+++ b/Makefile
@@ -44,29 +44,31 @@ ifeq ($(verbose), 1)
 endif
 
 # MPI
-ifeq ($(mpi), 1)
-  BUILDDIR := ${BUILDDIR}-mpi
-  CC = mpicc
-  CXX = mpicxx
-  FC = mpif90
-  CONFIG_FLAGS += -DHAVE_MPI=1
-else
-  ifeq ($(CC), not-set)
-    CC  = icc
-  endif
-  ifeq ($(CXX), not-set)
-    CXX = icpc
-  endif
-  ifeq ($(FC), not-set)
-    FC = ifort
-  endif
-  CONFIG_FLAGS += -DHAVE_MPI=0
-endif
+ifeq ($(ATS), not-set)
+	ifeq ($(mpi), 1)
+	  BUILDDIR := ${BUILDDIR}-mpi
+	  CC = mpicc
+	  CXX = mpicxx
+	  FC = mpif90
+	  CONFIG_FLAGS += -DHAVE_MPI=1
+	else
+	  ifeq ($(CC), not-set)
+	    CC  = icc
+	  endif
+	  ifeq ($(CXX), not-set)
+	    CXX = icpc
+	  endif
+	  ifeq ($(FC), not-set)
+	    FC = ifort
+	  endif
+	  CONFIG_FLAGS += -DHAVE_MPI=0
+	endif
 
-ifeq ($(FC),ifort)
-  compiler=intel
-else
-  compiler=gnu
+	ifeq ($(FC),ifort)
+	  compiler=intel
+	else
+	  compiler=gnu
+	endif
 endif
 # Shared libs?
 ifeq ($(shared), 1)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ FC         = not-set
 travis     = not-set
 F90        = not-set
 netcdfsys  = not-set
+ATS        = not-set
 # This proxies everything to the builddir cmake.
 
 
@@ -137,6 +138,10 @@ endif
 CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(NETCDF_FFLAGS)"
 CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(NETCDF_FLIBS)"
 
+ifeq ($(ATS), 1)
+	CONFIG_FLAGS += -DTPL_NETCDF_INCLUDE_DIRS="$(TPL_INSTALL_PREFIX)/include"
+	CONFIG_FLAGS += -DTPL_NETCDF_LIBRARIES="$(TPL_INSTALL_PREFIX)/lib"
+endif
 
 define run-config
 @mkdir -p $(BUILDDIR)

--- a/cmake/Modules/set_up_platform.cmake
+++ b/cmake/Modules/set_up_platform.cmake
@@ -61,6 +61,21 @@ endif()
     set(NEED_LAPACK FALSE)
   endif()
 
+# check if we are building within ATS and if so change the TPL dirs
+  if (ATS)
+    set(Z_LIBRARY "${TPL_INSTALL_PREFIX}/lib/libz.a")
+    set(Z_INCLUDE_DIR "${TPL_INSTALL_PREFIX}/include")
+    get_filename_component(Z_LIBRARY_DIR ${Z_LIBRARY} DIRECTORY)
+
+    set(HDF5_LIB_NAME hdf5)
+    set(HDF5_HL_LIB_NAME hdf5_hl)
+    set(HDF5_LIBRARY "${TPL_INSTALL_PREFIX}/lib/lib${HDF5_LIB_NAME}${LIB_SUFFIX}")
+    set(HDF5_HL_LIBRARY "${TPL_INSTALL_PREFIX}/lib/lib${HDF5_HL_LIB_NAME}${LIB_SUFFIX}")
+    set(HDF5_LIBRARIES ${HDF5_HL_LIB_NAME};${HDF5_LIB_NAME})
+    set(HDF5_INCLUDE_DIR "${TPL_INSTALL_PREFIX}/include")
+    get_filename_component(HDF5_LIBRARY_DIR ${Z_LIBRARY} DIRECTORY)
+  endif()
+
   # Certain tools (e.g. patch) require TMPDIR to be defined. If it is not,
   # we do so here.
   set(TMPDIR_VAR $ENV{TMPDIR})


### PR DESCRIPTION
Small changes to the makefiles so that EcoSIM can install through ATS. It links EcoSIM to ATS installations of netcdf, hdf5, and zlib, and adds an additional build option (ATS) which if set to 1 prevents the EcoSIM makefile from overwriting environment variables set in ATS.