### PR TITLE
fix nmlfile buffer truncation in driver entry points

### DIFF
--- a/drivers/ecosim/ecosim.F90
+++ b/drivers/ecosim/ecosim.F90
@@ -35,7 +35,7 @@ PROGRAM main
   integer :: nn1,nn2,nn3
   integer :: year_ini,nyr1,yeari,nstopyr
   CHARACTER(len=640):: BUF
-  character(len=36):: nmlfile
+  character(len=256):: nmlfile
   character(len=14) :: ymdhs
   character(len=14) :: ymdhs0
   logical :: is_dos,nlend

--- a/drivers/tools/HFileTest.F90
+++ b/drivers/tools/HFileTest.F90
@@ -13,7 +13,7 @@ program HFileTest
   real(r8), pointer :: TSOI(:)
   real(r8), pointer :: VSM(:)
   integer :: jh,jd
-  character(len=36):: nmlfile
+  character(len=256):: nmlfile
 
   character(len=256) :: ioerror_msg
   integer :: rc, fu

--- a/drivers/tools/etimerTest.F90
+++ b/drivers/tools/etimerTest.F90
@@ -14,7 +14,7 @@ PROGRAM etimerTest
   character(len=ecosim_namelist_buffer_size) :: nml_buffer
 
   real(r8) :: a(3)
-  character(len=36):: nmlfile
+  character(len=256):: nmlfile
   integer :: nyr, J,mon
   character(len=16) :: ymdhs
 

--- a/drivers/tools/restartTest.F90
+++ b/drivers/tools/restartTest.F90
@@ -9,7 +9,7 @@ implicit none
   character(len=*), parameter :: prognm=&
   __FILE__
 
-  character(len=36):: nmlfile
+  character(len=256):: nmlfile
 
   character(len=256) :: ioerror_msg
   integer :: rc, fu


### PR DESCRIPTION
The `nmlfile` buffer used to receive the namelist filename from the command line is declared `character(len=36)` in four driver
programs. Filenames longer than 36 characters are silently truncated, leading to a "file not found" error when the model tries to open the truncated path.

This PR extends the buffer to 256 characters in all four affected drivers, matching the existing convention already used in `drivers/tools/PlantManagementReader.F90:17`.

(This time I changed to 'next' branch to merge)
