### PR TITLE
Fix bundled dependency build

### DIFF
--- a/3rd-partylibs/CMakeLists.txt
+++ b/3rd-partylibs/CMakeLists.txt
@@ -234,7 +234,7 @@ if (EXISTS ${BLOSC_LIBRARY})
   message(STATUS "BLOSC_LIBRARY ${BLOSC_LIBRARY}")
 endif()
 
-if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/hdf5)
+if (NOT EXISTS ${HDF5_LIBRARY} OR NOT EXISTS ${HDF5_HL_LIBRARY})
   message("Preparing hdf5...")
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/hdf5 ${CMAKE_CURRENT_BINARY_DIR}/hdf5
                   RESULT_VARIABLE stat)
@@ -370,10 +370,13 @@ if (NOT EXISTS ${NETCDF_LIBRARY})
   message("NETCDF_CPPFLAGS: ${NETCDF_CPPFLAGS}")
   message("NETCDF_LIBFLAGS: ${NETCDF_LIBFLAGS}")
 
+  set(NETCDF_C_LIBS "-lhdf5_hl -lhdf5 -lz -ldl -lm")
+
   #Original version
   execute_process(COMMAND env CC=${CMAKE_C_COMPILER} env FC=${CMAKE_Fortran_COMPILER}
-    env CXX=${CMAKE_CXX_COMPILER} env CXXFLAGS=${CMAKE_CXX_FLAGS} env CPPFLAGS=-I${PROJECT_BINARY_DIR}/include
+    env CXX=${CMAKE_CXX_COMPILER} env CXXFLAGS=${CMAKE_CXX_FLAGS} env "CPPFLAGS=-D_GNU_SOURCE -I${PROJECT_BINARY_DIR}/include"
     env CFLAGS=${CMAKE_C_FLAGS} env LDFLAGS=-L${PROJECT_BINARY_DIR}/lib
+    env LIBS=${NETCDF_C_LIBS}
     ./configure ${NETCDF_C_CONFIG_OPTS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/netcdf-c
     OUTPUT_VARIABLE netcdf_c_config_log ERROR_VARIABLE netcdf_c_config_err


### PR DESCRIPTION
Fixes bundled dependency build failures seen when configuring EcoSIM from a partially built tree and with newer GCC/libc toolchains.

Changes:
- Rebuild HDF5 when required installed libraries are missing instead of checking only for the build directory.
- Link netCDF-C configure checks against libhdf5_hl as well as libhdf5.
- Add _GNU_SOURCE to netCDF-C CPPFLAGS so random() is visible.

Validation:
- Verified locally with CMake configure and a full CMake build during the original fix work.